### PR TITLE
fix: provide tag for native.git_tags

### DIFF
--- a/lua/blink/lib/native/init.lua
+++ b/lua/blink/lib/native/init.lua
@@ -62,7 +62,7 @@ end
 --- @param path string Where to save the library
 --- @param callback fun(err: string)
 function native.download(url, path, callback)
-  vim.fn.mkdir(vim.fs.dirname(path), 'p')
+  native.mkdirp(vim.fs.dirname(path))
   vim.net.request(url, { outpath = path }, function(err) callback(err) end)
 end
 

--- a/lua/blink/lib/native/init.lua
+++ b/lua/blink/lib/native/init.lua
@@ -189,10 +189,16 @@ function native.try_git_commit(path)
 end
 
 --- @param path string Path to the repository root or some path inside the repository
+--- @param tag string Tag to check for existence (e.g. 'v1.*')
 --- @return string? tag For example 'v0.0.1'
-function native.git_tag(path)
-  local process = vim.system({ 'git', 'describe', '--tags', '--exact-match' }, { cwd = path }):wait(1000)
-  if process.code == 0 then return process.stdout:match('(%w+)\n') end
+function native.git_tag(path, tag)
+  path = vim.fs.root(path, '.git') or path
+  local process = vim.system({ 'git', 'describe', '--tags', '--match', tag }, { cwd = path }):wait(1000)
+  if process.code == 0 and process.stdout then
+    local version = vim.version.parse(process.stdout)
+    if version then return ('v%d.%d.%d'):format(version.major, version.minor, version.patch) end
+    return process.stdout:match('(%w+)\n')
+  end
 end
 
 return native

--- a/lua/blink/lib/native/init.lua
+++ b/lua/blink/lib/native/init.lua
@@ -193,15 +193,10 @@ end
 --- @param match? string Tag to check for existence (e.g. 'v1.*')
 --- @return string? tag For example 'v0.0.1'
 function native.git_tag(path, match)
-  path = vim.fs.root(path, '.git') or path
-  local cmd = match and { 'git', 'describe', '--tags', '--match', match }
+  local cmd = match and { 'git', 'describe', '--tags', '--match', match, '--abbrev=0' }
     or { 'git', 'describe', '--tags', '--exact-match' }
   local process = vim.system(cmd, { cwd = path }):wait(1000)
-  if process.code == 0 and process.stdout then
-    local version = vim.version.parse(process.stdout)
-    if version then return ('v%d.%d.%d'):format(version.major, version.minor, version.patch) end
-    return process.stdout:match('(%w+)\n')
-  end
+  if process.code == 0 and process.stdout then return process.stdout:match('(%w+)\n') end
 end
 
 return native

--- a/lua/blink/lib/native/init.lua
+++ b/lua/blink/lib/native/init.lua
@@ -189,11 +189,13 @@ function native.try_git_commit(path)
 end
 
 --- @param path string Path to the repository root or some path inside the repository
---- @param tag string Tag to check for existence (e.g. 'v1.*')
+--- @param match? string Tag to check for existence (e.g. 'v1.*')
 --- @return string? tag For example 'v0.0.1'
-function native.git_tag(path, tag)
+function native.git_tag(path, match)
   path = vim.fs.root(path, '.git') or path
-  local process = vim.system({ 'git', 'describe', '--tags', '--match', tag }, { cwd = path }):wait(1000)
+  local cmd = match and { 'git', 'describe', '--tags', '--match', match }
+    or { 'git', 'describe', '--tags', '--exact-match' }
+  local process = vim.system(cmd, { cwd = path }):wait(1000)
   if process.code == 0 and process.stdout then
     local version = vim.version.parse(process.stdout)
     if version then return ('v%d.%d.%d'):format(version.major, version.minor, version.patch) end

--- a/lua/blink/lib/native/init.lua
+++ b/lua/blink/lib/native/init.lua
@@ -62,6 +62,7 @@ end
 --- @param path string Where to save the library
 --- @param callback fun(err: string)
 function native.download(url, path, callback)
+  vim.fn.mkdir(vim.fs.dirname(path), 'p')
   vim.net.request(url, { outpath = path }, function(err) callback(err) end)
 end
 


### PR DESCRIPTION
Provide at least a tag glob to `native.git_tags`, so it know which tag to search.
```lua
require("blink.cmp").download({ force = true, tags = "*" }):wait(60000)
```
