### PR TITLE
fix(native): make mkdirp synchronous to avoid mv race

### DIFF
--- a/lua/blink/lib/native/init.lua
+++ b/lua/blink/lib/native/init.lua
@@ -106,16 +106,9 @@ end
 --- Recursively creates a directory, no-op if the directory already exists
 --- @param path string
 function native.mkdirp(path)
-  vim.uv.fs_mkdir(path, 493, function(err)
-    if err then
-      -- parent might not exist, try creating it first
-      local parent = vim.fs.dirname(path)
-      if parent and parent ~= path then
-        native.mkdirp(parent)
-        vim.uv.fs_mkdir(path, 493)
-      end
-    end
-  end)
+  -- Synchronous so callers (like `native.mv`) can safely write into `path`
+  -- immediately afterwards without racing the directory creation.
+  vim.fn.mkdir(path, 'p')
 end
 
 --- Move a file from one location to another, creating all intermediate directories at dst


### PR DESCRIPTION
`native.mv` called `native.mkdirp` followed immediately by a synchronous `vim.uv.fs_rename`. Since `mkdirp` used async `vim.uv.fs_mkdir`, on a first-ever run (e.g. blink.cmp's build step moving the freshly compiled dylib into `$data/site/lib/`) the rename fired before the directory existed and failed with `ENOENT` - even though the async mkdir eventually succeeded, leaving an empty `lib/` dir behind and surfacing as a build failure to the user.

Replace the hand-rolled async recursion with `vim.fn.mkdir(path, 'p')`, which is synchronous and already handles missing parents. Callers can now safely write into `path` immediately after `mkdirp` returns.