### PR TITLE
fix(config): propagate validator error

### DIFF
--- a/lua/blink/lib/config.lua
+++ b/lua/blink/lib/config.lua
@@ -332,23 +332,24 @@ end
 --- Check a value against a type spec (list of strings/validators)
 --- @param val any
 --- @param t blink.lib.ConfigSchemaType
---- @return boolean
+--- @return boolean, string?
 function M.utils.validate_value(val, t)
   if M.types.is_validator(t) then
     local ok, err = t.validator(val)
-    return ok
+    return ok, err
   end
 
   if type(t) ~= 'table' then t = { t } end
   for _, t in ipairs(t) do
     if M.types.is_validator(t) then
       local ok, err = t.validator(val)
-      if ok then return true end
+      if ok then return true, nil end
     elseif type(val) == t then
-      return true
+      return true, nil
     end
   end
-  return false
+
+  return false, nil
 end
 
 --- Extracts the default values from a schema


### PR DESCRIPTION
Let M.utils.validate_value propagate the error message sent by validators instead of only returning whether validation succeeded.

This allows validators like list and map to provide custom error messages that M.validate can actually show to the user.
