### PR TITLE
feat: add support for loongarch64

### DIFF
--- a/lua/blink/download/system.lua
+++ b/lua/blink/download/system.lua
@@ -15,6 +15,7 @@ local system = {
       android = 'aarch64-linux-android',
       arm = function(libc) return 'aarch64-unknown-linux-' .. libc end,
       x64 = function(libc) return 'x86_64-unknown-linux-' .. libc end,
+      loongarch64 = function(libc) return 'loongarch64-unknown-linux-' .. libc end,
     },
     freebsd = {
       x64 = 'x86_64-unknown-freebsd',

--- a/lua/blink/lib/native/platform.lua
+++ b/lua/blink/lib/native/platform.lua
@@ -11,6 +11,7 @@ local platform = {
     linux = {
       arm64 = function(libc) return 'aarch64-unknown-linux-' .. libc end,
       x64 = function(libc) return 'x86_64-unknown-linux-' .. libc end,
+      loongarch64 = function(libc) return 'loongarch64-unknown-linux-' .. libc end,
     },
     android = {
       arm64 = 'aarch64-linux-android',
@@ -28,9 +29,9 @@ local platform = {
 }
 
 --- @alias blink.lib.native.OS 'windows'|'linux'|'mac'|'freebsd'|'openbsd'|'netbsd'|'bsd'|'other'
---- @alias blink.lib.native.Arch 'x86'|'x64'|'arm'|'arm64'|'arm64be'|'ppc'|'ppc64'|'ppc64le'|'mips'|'mipsel'|'mips64'|'mips64el'|string
+--- @alias blink.lib.native.Arch 'x86'|'x64'|'arm'|'arm64'|'arm64be'|'ppc'|'ppc64'|'ppc64le'|'mips'|'mipsel'|'mips64'|'mips64el'|'loongarch64'|string
 --- @alias blink.lib.native.Libc 'gnu'|'musl'
---- @alias blink.lib.native.Triple 'aarch64-apple-darwin'|'x86_64-apple-darwin'|'aarch64-pc-windows-msvc'|'x86_64-pc-windows-msvc'|'aarch64-unknown-linux-gnu'|'aarch64-unknown-linux-musl'|'aarch64-unknown-freebsd'|'x86_64-unknown-linux-gnu'|'x86_64-unknown-linux-musl'|'x86_64-unknown-freebsd'|'x86_64-unknown-openbsd'|'aarch64-unknown-openbsd'
+--- @alias blink.lib.native.Triple 'aarch64-apple-darwin'|'x86_64-apple-darwin'|'aarch64-pc-windows-msvc'|'x86_64-pc-windows-msvc'|'aarch64-unknown-linux-gnu'|'aarch64-unknown-linux-musl'|'aarch64-unknown-freebsd'|'x86_64-unknown-linux-gnu'|'x86_64-unknown-linux-musl'|'x86_64-unknown-freebsd'|'x86_64-unknown-openbsd'|'aarch64-unknown-openbsd'|'loongarch64-unknown-linux-gnu'|'loongarch64-unknown-linux-musl'
 --- @alias blink.lib.native.LibExtension '.so'|'.dylib'|'.dll'
 
 --- @class blink.lib.native.Platform


### PR DESCRIPTION
On the LoongArch architecture, the following information is available:
```
$ uname -a
Linux 3a6kpc 7.0.9-arch1-1 #1 SMP PREEMPT_DYNAMIC Sun, 24 May 2026 03:58:08 +0000 loongarch64 GNU/Linux
$ cat test.lua 
os = jit.os:lower()
arch = jit.arch
print(os)
print(arch)
$ nvim -l test.lua 
linux
loongarch64
```