### PR TITLE
fix(native): re-read git commit before build/download

### DIFF
--- a/lua/blink/lib/native/managed.lua
+++ b/lua/blink/lib/native/managed.lua
@@ -41,6 +41,10 @@ function managed:build(command, get_artifact_paths, opts)
       assert(self.repo_root ~= nil, 'Could not find git repo root, did you install via a package manager?')
       vim.opt.runtimepath:append(self.repo_root)
 
+      -- the commit may have changed since this module was loaded, so re-read it
+      local current_commit = native.try_git_commit(self.repo_root)
+      if current_commit ~= nil then self.git_commit = current_commit end
+
       opts = opts or {}
       if not opts.force and self:library_available() then return end
 
@@ -88,6 +92,10 @@ function managed:download(get_download_url, opts)
       -- ensure repository is available for native.resolve()
       assert(self.repo_root ~= nil, 'Could not find git repo root, did you install via a package manager?')
       vim.opt.runtimepath:append(self.repo_root)
+
+      -- the commit may have changed since the module was loaded, so re-read it
+      local current_commit = native.try_git_commit(self.repo_root)
+      if current_commit ~= nil then self.git_commit = current_commit end
 
       opts = opts or {}
       if not opts.force and self:library_available() then return resolve() end


### PR DESCRIPTION
After updating `blink.cmp` with `lazy.nvim`, `blink.cmp` doesn't rebuild after the update (with [the suggested config](https://github.com/emreorta/dotfiles/blob/120ef930b8f97b056a4ea77bb84698fd6153c34f/nvim/lua/plugins/autocomplete.lua#L7-L99)) and outputs the following warning after launching a new session:

```
blink.cmp  V2 uses a new build/download system for the native library. Please add  build = function() require('blink.cmp').build():pwait() end to your lazy.nvim config. See  :h blink-cmp-installation  for more information.
```

Re-reading the commit at the start of `build()` and `download()` instead of trusting the cached value seems to fix the issue. Tested the change locally and update went fine with the build.