### PR TITLE
refactor: improve Lua types

### DIFF
--- a/lua/blink/download/config.lua
+++ b/lua/blink/download/config.lua
@@ -1,5 +1,11 @@
 return {
+  ---@type string?
   force_system_triple = nil,
-  proxy = { url = nil, from_env = true },
+  proxy = {
+    ---@type string?
+    url = nil,
+    from_env = true,
+  },
+  ---@type string[]
   extra_curl_args = {},
 }

--- a/lua/blink/download/downloader.lua
+++ b/lua/blink/download/downloader.lua
@@ -8,7 +8,7 @@ local downloader = {}
 --- @param files blink.lib.download.files
 --- @param get_download_url fun(version: string, system_triple: string, extension: string): string
 --- @param version string
---- @return blink.lib.Task
+--- @return blink.lib.Task<integer?>
 function downloader.download(files, get_download_url, version)
   -- set the version to 'v0.0.0' to avoid a failure causing the pre-built binary being marked as locally built
   return files
@@ -39,7 +39,7 @@ end
 --- @param files blink.lib.download.files
 --- @param url string
 --- @param filename string
---- @return blink.lib.Task
+--- @return blink.lib.Task<vim.SystemObj?>
 function downloader.download_file(files, url, filename)
   return task.new(function(resolve, reject)
     local args = { 'curl' }

--- a/lua/blink/download/files.lua
+++ b/lua/blink/download/files.lua
@@ -31,15 +31,15 @@ function M.new(root_dir, output_dir, binary_name)
   return self
 end
 
---- @return blink.lib.Task<{ version?: string; missing?: boolean }>
+--- @return blink.lib.Task<{ version?: string, missing: boolean }>
 function M:get_version()
   return fs.read(self.version_path, 1024)
     :map(function(version) return { version = version, missing = false } end)
-    :catch(function() return { missing = true } end)
+    :catch(function() return { missing = true } end) --[[@as blink.lib.Task<{ version?: string, missing: boolean }>]]
 end
 
 --- @param version string
---- @return blink.lib.Task
+--- @return blink.lib.Task<integer?>
 function M:set_version(version)
   return fs.mkdir(self.root_dir .. '/target')
     :map(function() return fs.mkdir(self.lib_folder) end)
@@ -49,8 +49,9 @@ end
 --- Get the extension for the library based on the current platform, including the dot (i.e. '.so' or '.dll')
 --- @return string
 function M.get_lib_extension()
-  if jit.os:lower() == 'mac' or jit.os:lower() == 'osx' then return '.dylib' end
-  if jit.os:lower() == 'windows' then return '.dll' end
+  local os = jit.os:lower()
+  if os == 'mac' or os == 'osx' then return '.dylib' end
+  if os == 'windows' then return '.dll' end
   return '.so'
 end
 

--- a/lua/blink/download/git.lua
+++ b/lua/blink/download/git.lua
@@ -4,7 +4,7 @@ local task = require('blink.lib.task')
 local git = {}
 
 --- @param root_dir string
---- @return blink.lib.Task
+--- @return blink.lib.Task<{ tag?: string }>
 function git.get_version(root_dir)
   return task.new(function(resolve, reject)
     vim.system({ 'git', 'describe', '--tags', '--exact-match' }, { cwd = root_dir }, function(out)
@@ -13,11 +13,11 @@ function git.get_version(root_dir)
         return reject('While getting git tag, git exited with code ' .. out.code .. ': ' .. out.stderr)
       end
 
-      local lines = vim.split(out.stdout, '\n')
-      if not lines[1] then return reject('Expected atleast 1 line of output from git describe') end
+      local lines = out.stdout and vim.split(out.stdout, '\n') or {}
+      if not lines[1] then return reject('Expected at least 1 line of output from git describe') end
       return resolve({ tag = lines[1] })
     end)
-  end)
+  end) --[[@as blink.lib.Task<{ tag?: string }>]]
 end
 
 return git

--- a/lua/blink/download/init.lua
+++ b/lua/blink/download/init.lua
@@ -2,7 +2,7 @@ local task = require('blink.lib.task')
 
 --- @class blink.lib.download.Opts
 --- @field download_url? fun(version: string, system_triple: string, extension: string): string
---- @field on_download fun()
+--- @field on_download? fun()
 --- @field root_dir string
 --- @field output_dir string
 --- @field binary_name string

--- a/lua/blink/download/system.lua
+++ b/lua/blink/download/system.lua
@@ -29,13 +29,13 @@ local system = {
 }
 
 --- Gets the operating system and architecture of the current system
---- @return string, string
+--- @return string, "x64"|"arm"?
 function system.get_info()
   local os = jit.os:lower()
   if os == 'osx' then os = 'mac' end
 
   if os == 'bsd' then
-    local sysname = vim.loop.os_uname().sysname:lower()
+    local sysname = vim.uv.os_uname().sysname:lower()
     if sysname == 'freebsd' then
       os = 'freebsd'
     elseif sysname == 'openbsd' then
@@ -82,13 +82,13 @@ end
 
 --- Gets the system triple for the current system
 --- for example, `x86_64-unknown-linux-gnu` or `aarch64-apple-darwin`
---- @return blink.lib.Task
+--- @return blink.lib.Task<string?>
 function system.get_triple()
   return task.new(function(resolve, reject)
     if config.force_system_triple then return resolve(config.force_system_triple) end
 
     local os, arch = system.get_info()
-    local triples = system.triples[os]
+    local triples = assert(system.triples[os], 'OS ' .. os .. ' is not supported')
 
     if os == 'linux' then
       if vim.fn.has('android') == 1 then return resolve(triples.android) end

--- a/lua/blink/lib/_/list/filter_map.lua
+++ b/lua/blink/lib/_/list/filter_map.lua
@@ -3,7 +3,7 @@
 --- @generic T
 --- @generic U
 --- @param list T[]
---- @param fn fun(item: T, idx: number): U?
+--- @param fn fun(item: T, idx: integer): U?
 --- @return U[]
 local function filter_map(list, fn)
   local result = {}

--- a/lua/blink/lib/_/list/find_idx.lua
+++ b/lua/blink/lib/_/list/find_idx.lua
@@ -2,7 +2,7 @@
 --- @generic T
 --- @param list T[]
 --- @param predicate fun(item: T): boolean
---- @return number?
+--- @return integer?
 local function find_idx(list, predicate)
   for idx, v in ipairs(list) do
     if predicate(v) then return idx end

--- a/lua/blink/lib/_/list/index_of.lua
+++ b/lua/blink/lib/_/list/index_of.lua
@@ -2,7 +2,7 @@
 --- @generic T
 --- @param list T[]
 --- @param val T
---- @return number?
+--- @return integer?
 local function index_of(list, val)
   for idx, v in ipairs(list) do
     if v == val then return idx end

--- a/lua/blink/lib/_/list/map.lua
+++ b/lua/blink/lib/_/list/map.lua
@@ -2,7 +2,7 @@
 --- @generic T
 --- @generic U
 --- @param list T[]
---- @param fn fun(item: T, idx: number): U
+--- @param fn fun(item: T, idx: integer): U
 --- @return U[]
 local function map(list, fn)
   local result = {}

--- a/lua/blink/lib/bench/init.lua
+++ b/lua/blink/lib/bench/init.lua
@@ -49,7 +49,7 @@ function M.run_files(filter)
 end
 
 function M.run_file()
-  local file = vim.fs.relpath(vim.fn.getcwd(), vim.fn.expand('%:p'))
+  local file = vim.fs.relpath(vim.fn.getcwd(), vim.fn.expand('%:p') --[[@as string]])
   M.run_files(file)
 end
 
@@ -59,7 +59,7 @@ end
 
 --- @param group string | string[]
 --- @param default_opts? blink.lib.bench.RunOpts
---- @return blink.lib.bench.Group
+--- @return blink.lib.bench.RunOpts
 function M.group(group, default_opts)
   if type(group) == 'string' then group = { group } end
   return {
@@ -82,7 +82,7 @@ end
 --- @field group string[] Current group of benchmarks (default: {})
 --- @field warmup string Time to spend warming up before starting measurements (default: 500ms)
 --- @field measurement string Time to spend measuring (default: 5s)
---- @field min_samples integer Minimum number of samples to take (default: 10)
+--- @field min_samples integer Minimum of samples to take (default: 10)
 --- @field output boolean | 'verbose' Print output (default: true)
 --- @field save boolean Save output to file (default: true)
 

--- a/lua/blink/lib/bench/stats.lua
+++ b/lua/blink/lib/bench/stats.lua
@@ -28,6 +28,7 @@ end
 
 function M.std_dev(t, m)
   m = m or M.mean(t)
+  ---@type number
   local s = 0
   for i = 1, #t do
     local d = t[i] - m
@@ -72,6 +73,7 @@ function M.bootstrap_ci_slope(batch_sizes, batch_times, confidence, resamples)
 
   local slopes = {}
   for r = 1, resamples do
+    ---@type number, number
     local sxx, sxy = 0, 0
     for _ = 1, n do
       local i = math.random(n)
@@ -90,6 +92,7 @@ end
 --- Given batch sizes xs and batch times ys, returns per-op cost k.
 --- Using through-origin fit because a batch of 0 ops takes 0 time.
 function M.fit_slope(xs, ys)
+  ---@type number, number
   local sxx, sxy = 0, 0
   for i = 1, #xs do
     sxx = sxx + xs[i] * xs[i]

--- a/lua/blink/lib/bench/utils.lua
+++ b/lua/blink/lib/bench/utils.lua
@@ -39,8 +39,8 @@ end
 function M.parse_duration(d)
   if type(d) == 'number' then return d * 1e9 end
   local n, unit = d:match('^(%d+%.?%d*)(%a+)$')
-  assert(n, 'invalid duration: ' .. tostring(d))
   n = tonumber(n)
+  assert(n, 'invalid duration: ' .. tostring(d))
   if unit == 'ns' then return n end
   if unit == 'us' then return n * 1e3 end
   if unit == 'ms' then return n * 1e6 end

--- a/lua/blink/lib/fs/init.lua
+++ b/lua/blink/lib/fs/init.lua
@@ -20,7 +20,7 @@ end
 
 --- Gets a list of all items in a directory asynchronously
 --- @param path string
---- @param max_entries? integer Maximum number of entries to return
+--- @param max_entries? integer Maximum of entries to return
 --- @return blink.lib.Task<blink.lib.fs.DirEntry[]>
 function fs.list_dir(path, max_entries)
   -- TODO: create a helper for working with iters in `blink.lib.task`?
@@ -49,9 +49,9 @@ fs.list_dir_iter = require('blink.lib.fs.list_dir_iter')
 
 --- Equivalent to `preadv(2)`. Returns a string where an empty string indicates EOF
 --- @param path string
---- @param size number
---- @param offset number?
---- @return blink.lib.Task<string>
+--- @param size integer
+--- @param offset integer?
+--- @return blink.lib.Task<string?>
 function fs.read(path, size, offset)
   return task.new(function(resolve, reject)
     uv.fs_open(path, 'r', 438, function(open_err, fd)
@@ -68,8 +68,8 @@ end
 --- Equivalent to `pwritev(2)`. Returns the number of bytes written
 --- @param path string
 --- @param data string
---- @param offset number?
---- @return blink.lib.Task<number>
+--- @param offset integer?
+--- @return blink.lib.Task<integer?>
 function fs.write(path, data, offset)
   return task.new(function(resolve, reject)
     uv.fs_open(path, 'w', 438, function(open_err, fd)

--- a/lua/blink/lib/fs/list_dir_iter.lua
+++ b/lua/blink/lib/fs/list_dir_iter.lua
@@ -8,8 +8,8 @@ local uv = vim.uv
 --- Scans a directory asynchronously in chunks, returning an iterator function that yields
 --- each chunk of entries.
 --- @param path string
---- @param chunk_size? integer Number of entries to return per chunk
---- @return blink.lib.Task<function(): blink.lib.Task<blink.lib.fs.DirEntry[]?>>
+--- @param chunk_size? integer Entries to return per chunk
+--- @return blink.lib.Task<fun(): blink.lib.Task<blink.lib.fs.DirEntry[]?>>
 local function list_dir_iter(path, chunk_size)
   return task.new(function(resolve, reject)
     uv.fs_opendir(path, function(err, dir)

--- a/lua/blink/lib/lazy_require.lua
+++ b/lua/blink/lib/lazy_require.lua
@@ -1,4 +1,5 @@
 local function lazy_require(module_name)
+  ---@type any
   local module
   return setmetatable({}, {
     __index = function(_, key)

--- a/lua/blink/lib/log.lua
+++ b/lua/blink/lib/log.lua
@@ -22,7 +22,7 @@ local levels_to_str = {
 
 --- @class blink.lib.LoggerConsoleOptions
 --- @field enabled? boolean
---- @field min_log_level? number
+--- @field min_log_level? integer
 ---
 --- @class blink.lib.LoggerFileOptions : blink.lib.LoggerConsoleOptions
 --- @field path? string
@@ -46,7 +46,7 @@ function logger:open() vim.cmd('edit ' .. self.opts.file.path) end
 --- logger:log(vim.log.levels.INFO, 'message %s', { foo = true })
 --- ```
 ---
---- @param level number
+--- @param level integer
 --- @param msg string
 --- @param ... any
 function logger:log(level, msg, ...)
@@ -140,7 +140,7 @@ function logger:error(msg, ...) self:log(vim.log.levels.ERROR, msg, ...) end
 --- log:notify(vim.log.levels.INFO, { { 'chunk1-line1\nchunk1-line2\n' }, { 'chunk2-line1' } }, true, {})
 --- ```
 ---
---- @param level number Level from `vim.log.levels.*`
+--- @param level integer Level from `vim.log.levels.*`
 --- @param chunks string | [string, integer|string?][] List of `[text, hl_group]` pairs, where each is a `text` string highlighted by
 --- the (optional) name or ID `hl_group`.
 --- @param history boolean? if false, do not add to `message-history`.

--- a/lua/blink/lib/lsp/server.lua
+++ b/lua/blink/lib/lsp/server.lua
@@ -5,7 +5,7 @@
 ---   Async: call `ctx.respond(result, err)`, optionally returning a cancellation function
 ---
 --- @param opts blink.lib.lsp.server.Opts
---- @return fun(dispatchers: vim.lsp.rpc.Dispatchers): vim.lsp.rpc.PublicClient
+--- @return fun(dispatchers: vim.lsp.rpc.Dispatchers): vim.lsp.rpc.Client
 local function new(opts)
   local name = opts.name
   local handlers = opts.handlers or {}

--- a/lua/blink/lib/native/init.lua
+++ b/lua/blink/lib/native/init.lua
@@ -8,11 +8,11 @@ local native = {}
 --- @return blink.lib.native.Platform
 function native.platform()
   local platform = require('blink.lib.native.platform')
-  local os = platform.os()
+  local platform_os = platform.os()
   local arch = platform.arch()
-  local libc = platform.libc(os)
-  local triple = platform.triple(os, arch, libc)
-  return { os = os, arch = arch, libc = libc, triple = triple, lib_extension = lib_extension }
+  local libc = platform.libc(platform_os)
+  local triple = platform.triple(platform_os, arch, libc)
+  return { os = platform_os, arch = arch, libc = libc, triple = triple, lib_extension = lib_extension }
 end
 
 --- @param repo_root string Root of the repository
@@ -78,12 +78,12 @@ function native.download(url, path, callback)
     vim.uv.fs_unlink(new_path)
   end
 
-  vim.net.request(url, { outpath = path }, function(err) callback(err) end)
+  vim.net.request(url, { outpath = path }, function(err) callback(tostring(err)) end)
 end
 
 --- @param url string
 --- @param path string Where to save the library
---- @return blink.lib.Task
+--- @return blink.lib.Task<nil>
 function native.download_async(url, path)
   return require('blink.lib.task').wrap(function(callback) native.download(url, path, callback) end)
 end
@@ -91,7 +91,7 @@ end
 --- @param cwd string
 --- @param cmd string[]
 --- @param logger blink.lib.Logger
---- @param callback fun(err?: string, process: vim.SystemCompleted)
+--- @param callback fun(err?: string, process?: vim.SystemCompleted)
 function native.exec(cwd, cmd, logger, callback)
   logger:write_to_file('---\n')
   logger:write_to_file('Working directory: ' .. cwd .. '\n')
@@ -128,7 +128,7 @@ end
 --- Recursively creates a directory, no-op if the directory already exists
 --- @param path string
 function native.mkdirp(path)
-  local ok, err = vim.uv.fs_mkdir(path, 493)
+  local _, err = vim.uv.fs_mkdir(path, 493)
   if err then
     -- parent might not exist, try creating it first
     local parent = vim.fs.dirname(path)
@@ -160,7 +160,7 @@ function native.git_repo_root(path)
   return vim.fn.fnamemodify(git_dir, ':h')
 end
 
---- @param path string Path to the repository root or some path inside the repository
+--- @param repo_root string Path to the repository root or some path inside the repository
 --- @return string commit_hash For example 'e5678fe566e86553403b3129a3684389c84fafb5'
 function native.git_commit(repo_root)
   --- @param p string

--- a/lua/blink/lib/native/managed.lua
+++ b/lua/blink/lib/native/managed.lua
@@ -4,6 +4,11 @@ local native = require('blink.lib.native')
 local task = require('blink.lib.task')
 
 --- @class blink.lib.native.managed
+--- @field module_name string
+--- @field library_name string
+--- @field logger blink.lib.Logger
+--- @field repo_root string
+--- @field git_commit string?
 local managed = {}
 
 --- @class blink.lib.native.managed.Opts
@@ -31,7 +36,7 @@ function managed:library_available() return native.resolve(self.library_name, se
 --- @param command string[]
 --- @param get_artifact_paths fun(repo_root: string, platform: blink.lib.native.Platform): string[] Returns a list of all possible artifact paths, ordered by preference
 --- @param opts? { force?: boolean, dev?: boolean }
---- @return blink.lib.Task
+--- @return blink.lib.Task<nil>
 function managed:build(command, get_artifact_paths, opts)
   local logger = self.logger
   return task
@@ -78,13 +83,13 @@ function managed:build(command, get_artifact_paths, opts)
     :catch(function(build_err)
       logger:notify(vim.log.levels.ERROR, 'Failed to build ' .. self.module_name .. ' native library: ' .. build_err)
       error(build_err)
-    end)
+    end) --[[@as blink.lib.Task<nil>]]
 end
 
 --- Downloads the precompiled library if it's not already available
 --- @param get_download_url fun(git_tag: string, platform: blink.lib.native.Platform): string
 --- @param opts? { force?: boolean, match?: string }
---- @return blink.lib.Task
+--- @return blink.lib.Task<nil>
 function managed:download(get_download_url, opts)
   local logger = self.logger
   return task
@@ -129,7 +134,7 @@ function managed:download(get_download_url, opts)
         'Failed to download ' .. self.module_name .. ' native library: ' .. download_err
       )
       error(download_err)
-    end)
+    end) --[[@as blink.lib.Task<nil>]]
 end
 
 return managed

--- a/lua/blink/lib/native/platform.lua
+++ b/lua/blink/lib/native/platform.lua
@@ -47,7 +47,7 @@ function platform.os()
   local os = jit.os:lower()
   if os == 'osx' then os = 'mac' end
   if os == 'bsd' then
-    local sysname = vim.loop.os_uname().sysname:lower()
+    local sysname = vim.uv.os_uname().sysname:lower()
     if sysname == 'freebsd' or sysname == 'openbsd' or sysname == 'netbsd' then os = sysname end
   end
   return os
@@ -68,7 +68,7 @@ function platform.libc(os)
   local head = vim.uv.fs_read(fd, 4096, 0)
   vim.uv.fs_close(fd)
 
-  return head:match('musl') and 'musl' or 'gnu'
+  return head and head:match('musl') and 'musl' or 'gnu'
 end
 
 --- Gets the system triple for the current system

--- a/lua/blink/lib/task.lua
+++ b/lua/blink/lib/task.lua
@@ -107,7 +107,6 @@ function task.wrap(fn)
   end)
 end
 
---- @param self blink.lib.Task<any>
 function task:cancel()
   if self.status ~= STATUS.RUNNING then return end
   self.status = STATUS.CANCELLED
@@ -127,7 +126,6 @@ end
 --- This only applies if the input task completed successfully.
 --- @generic T
 --- @generic U
---- @param self blink.lib.Task<`T`>
 --- @param fn fun(result: T): blink.lib.Task<`U`> | `U` | nil
 --- @return blink.lib.Task<U>
 function task:map(fn)
@@ -183,7 +181,6 @@ end
 --- events
 
 --- @generic T
---- @param self blink.lib.Task<T>
 --- @param cb fun(result: T)
 --- @return blink.lib.Task<T>
 function task:on_resolve(cb)
@@ -196,7 +193,6 @@ function task:on_resolve(cb)
 end
 
 --- @generic T
---- @param self blink.lib.Task<T>
 --- @param cb fun(err: any)
 --- @return blink.lib.Task<T>
 function task:on_reject(cb)
@@ -302,14 +298,12 @@ end
 
 --- Makes the task infallible, returning true if the task resolved successfully and false if the task rejected.
 --- @generic T
---- @param self blink.lib.Task<T>
 --- @return blink.lib.Task<boolean>
 function task:ok(fn)
   return self:map(function() return true end):catch(function() return false end)
 end
 
 --- @generic T
---- @param self blink.lib.Task<T>
 --- @return blink.lib.Task<T>
 function task:schedule()
   return self:map(function(value)
@@ -320,7 +314,6 @@ function task:schedule()
 end
 
 --- @generic T
---- @param self blink.lib.Task<T>
 --- @return blink.lib.Task<nil>
 function task:void()
   return self:map(function() end)
@@ -328,8 +321,7 @@ end
 
 --- Fails if the task doesn't complete within the given number of milliseconds.
 --- @generic T
---- @param self blink.lib.Task<T>
---- @param ms number
+--- @param ms integer
 --- @return blink.lib.Task<T>
 function task:timeout(ms)
   return task.new(function(resolve, reject)
@@ -344,8 +336,7 @@ end
 --- Blocks until the task completes, fails, or is cancelled.
 --- Must be called from the main thread (not from a fast callback).
 --- @generic T
---- @param self blink.lib.Task<T>
---- @param timeout number Timeout in milliseconds
+--- @param timeout integer Timeout in milliseconds
 --- @return T? result
 function task:wait(timeout)
   vim.wait(timeout or vim._maxint, function() return self.status ~= STATUS.RUNNING end)


### PR DESCRIPTION
Mostly the same kind of cleanup as the recent blink.cmp changes: improve annotations, fix inaccurate types, and address analyzer warnings while keeping runtime behavior unchanged.
